### PR TITLE
Add persistentHint.

### DIFF
--- a/src/component.vue
+++ b/src/component.vue
@@ -32,6 +32,7 @@
          :disabled="disabled"
          :readonly="readonly"
          :hint="hint"
+         :persistentHint="persistentHint"
          :light="light"
          :background-color="backgroundColor"
          :error="error"
@@ -123,6 +124,7 @@ export default {
     height: String,
     backgroundColor: String,
     hint: String,
+    persistentHint: String,
     error: Boolean,
     errorCount: {
       type: [Number, String],


### PR DESCRIPTION
The hint property on text fields adds the provided string beneath the text field. Using persistent-hint keeps the hint visible when the text field is not focused. Hint prop is not supported in solo mode