### PR TITLE
fix: add `inheritAttrs: false` to prevent double inheritance of attrs

### DIFF
--- a/src/VCurrencyField.vue
+++ b/src/VCurrencyField.vue
@@ -20,6 +20,7 @@ import defaults from './options';
 
 export default {
   name: 'VCurrencyField',
+  inheritAttrs: false,
   props: {
     value: {
       type: [Number, String],


### PR DESCRIPTION
This fixes `tabindex` support, which is broken because it was getting applied to the outermost vuetify `.v-input` div due to automatic attribute inheritance.

This component provides its own manual attribute inheritance with `v-bind=$attrs`, so the automatic inheritance provided by Vue is not needed and is indeed harmful.